### PR TITLE
Update DCC++ & DCC++EX Public Viewable Portals

### DIFF
--- a/DCC++ & DCC++EX Public Viewable Portals
+++ b/DCC++ & DCC++EX Public Viewable Portals
@@ -27,6 +27,8 @@ Web Sites:,
  https://www.youtube.com/channel/UCJmvQx-fe0OMAIH-_g-_rZw   Over 4,500 subscribers to date.
  https://dccwiki.com/DCC_Projects					                  Errors in texts 18v AC  should be 18v DC
  https://www.jmri.org/help/en/html/hardware/dccpp/index.shtml “Need Updating to refer to DCC++Classic & DCC++EX”
+ https://jmri-developers.groups.io/g/jmri/search?ev=0&q=%23dccpp #DCCpp JMRI Developers Group Needs a Landing Page Intro for DCC++EX 
+ https://jmri-developers.groups.io/g/jmri/search?q=posterid:4098247  JMRI Developers Group Needs updating to Reference the Discord Support Site
  https://www.trainboard.com/highball/index.php?threads/introducing-dcc-a-complete-open-source-dcc-station-and-interface.84800/
                                                               “Needs Clearer Notification of DCC++ to EX Support”
 DCC++EX Command Station 


### PR DESCRIPTION
Added JMRI Development Group URLs which need updating to depict current phase of DCC++EX 3.1 Dev and the Discord Support channel